### PR TITLE
improve the bash script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,13 @@ CFLAGS = -c -g -D $(TARGET)
 
 # Content of the pre-commit hook
 define PRECOMMIT
-#!/bin/sh
-make lint
+#!/usr/bin/env sh
+
+main() {
+	make lint
+}
+
+main
 endef
 export PRECOMMIT
 


### PR DESCRIPTION
Done the following to improve it:

- make it more portable with `#!/usr/bin/env sh`
- use best practices for bash scripts

For reference see:
- https://github.com/progrium/bashstyle
- https://unix.stackexchange.com/questions/29608/why-is-it-better-to-use-usr-bin-env-name-instead-of-path-to-name-as-my
